### PR TITLE
test: 落地第一阶段离线测试骨架（unit/cli/integration）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the systematic-literature-review skill will be documented
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+### Added（最小离线测试骨架 - 2026-03-09）
+
+- 新增正式测试目录：`tests/unit`、`tests/cli`、`tests/integration`、`tests/fixtures`
+- 为 `validate_counts.py`、`select_references.py`、`plan_word_budget.py`、`config_loader.py` 增加高价值单元测试
+- 新增 CLI 契约测试：覆盖 `validate_counts.py --help` 与缺失输入的失败退出码
+- 新增离线集成链路测试：`dedupe -> select -> word_budget`，断言关键产物存在与结构稳定
+- 在 `README.md` 补充 pytest 运行方式，并将 `pytest` 加入 `requirements.txt`
+
 ### Fixed（检索与摘要补齐的可控性/可复现性 - 2026-01-25）
 
 - `multi_query_search.py`：未提供查询时不再静默回退到硬编码查询，改为直接报错（避免误跑无关主题）

--- a/README.md
+++ b/README.md
@@ -295,3 +295,19 @@ python scripts/multi_language.py --tex-file review.tex --restore
 ### 详细文档
 
 详见 [`skill-references/multilingual-guide.md`](skill-references/multilingual-guide.md)
+
+## 测试（离线）
+
+本仓库已引入 `pytest` 作为正式测试框架，并采用分层目录：
+
+- `tests/unit/`：纯函数/规则测试
+- `tests/cli/`：CLI 参数与退出码契约测试
+- `tests/integration/`：离线脚本链路联调测试
+- `tests/fixtures/`：固定测试输入样本
+
+建议本地最小回归命令：
+
+```bash
+python3 -m py_compile scripts/*.py
+pytest -q tests/unit tests/cli
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests>=2.31
 numpy>=1.24
 scikit-learn>=1.3
 matplotlib>=3.7
+pytest>=8.0

--- a/tests/cli/test_cli_contracts.py
+++ b/tests/cli/test_cli_contracts.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_validate_counts_help() -> None:
+    cp = subprocess.run(
+        ["python3", "scripts/validate_counts.py", "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert cp.returncode == 0
+    assert "--tex" in cp.stdout
+
+
+def test_validate_counts_fail_on_missing_tex(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("review_levels:\n  default: premium\n", encoding="utf-8")
+
+    cp = subprocess.run(
+        [
+            "python3",
+            "scripts/validate_counts.py",
+            "--tex",
+            str(tmp_path / "missing.tex"),
+            "--config",
+            str(cfg),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert cp.returncode == 2
+    assert "tex 不存在" in cp.stderr

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = ROOT / "scripts"
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))

--- a/tests/fixtures/minimal_review_bad.tex
+++ b/tests/fixtures/minimal_review_bad.tex
@@ -1,0 +1,4 @@
+\\documentclass{article}
+\\begin{document}
+太短。
+\\end{document}

--- a/tests/fixtures/minimal_review_ok.tex
+++ b/tests/fixtures/minimal_review_ok.tex
@@ -1,0 +1,5 @@
+\\documentclass{article}
+\\begin{document}
+这是一个最小合法正文，包含足够的中文词语与 English words。
+参考文献见 \\cite{ref1,ref2}。
+\\end{document}

--- a/tests/fixtures/papers_raw.jsonl
+++ b/tests/fixtures/papers_raw.jsonl
@@ -1,0 +1,4 @@
+{"id":"p1","doi":"10.1000/a","title":"Paper A","year":2021,"score":9.1,"subtopic":"模型","abstract":"这是一段足够长的摘要内容，用于通过最小摘要长度检查。"}
+{"id":"p2","doi":"10.1000/b","title":"Paper B","year":2020,"score":8.4,"subtopic":"模型","abstract":"This is a sufficiently long abstract to satisfy selection constraints in offline tests."}
+{"id":"p3","doi":"10.1000/c","title":"Paper C","year":2022,"score":7.9,"subtopic":"数据","abstract":"Another long abstract for integration testing without any external API dependency."}
+{"id":"p3-dup","doi":"10.1000/c","title":"Paper C Duplicate","year":2022,"score":1.0,"subtopic":"数据","abstract":"duplicate"}

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -1,0 +1,18 @@
+scoring:
+  default_word_range:
+    premium:
+      min: 900
+      max: 1100
+word_budget:
+  ratio:
+    cited: 0.7
+    non_cited: 0.3
+  summary_ratio: 0.55
+  commentary_ratio: 0.45
+  noise_strength: 0.0
+  seeds: [17, 23, 43]
+  tolerance: 0.05
+  outputs:
+    run_pattern: word_budget_run{n}.csv
+    final: word_budget_final.csv
+    non_cited: non_cited_budget.csv

--- a/tests/integration/test_offline_chain.py
+++ b/tests/integration/test_offline_chain.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "tests" / "fixtures"
+
+
+def run(cmd: list[str], workdir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=workdir, text=True, capture_output=True, check=False)
+
+
+def test_dedupe_select_word_budget_chain(tmp_path: Path) -> None:
+    deduped = tmp_path / "papers_deduped.jsonl"
+    merge_map = tmp_path / "merge_map.json"
+    selected = tmp_path / "selected.jsonl"
+    bib = tmp_path / "references.bib"
+    rationale = tmp_path / "selection_rationale.yaml"
+    artifacts = tmp_path / "artifacts"
+
+    cp1 = run(
+        [
+            "python3",
+            "scripts/dedupe_papers.py",
+            "--input",
+            str(FIXTURES / "papers_raw.jsonl"),
+            "--output",
+            str(deduped),
+            "--map",
+            str(merge_map),
+        ],
+        ROOT,
+    )
+    assert cp1.returncode == 0, cp1.stderr
+
+    cp2 = run(
+        [
+            "python3",
+            "scripts/select_references.py",
+            "--input",
+            str(deduped),
+            "--output",
+            str(selected),
+            "--bib",
+            str(bib),
+            "--selection",
+            str(rationale),
+            "--min-refs",
+            "2",
+            "--max-refs",
+            "3",
+            "--target-refs",
+            "3",
+            "--min-abstract-chars",
+            "20",
+        ],
+        ROOT,
+    )
+    assert cp2.returncode == 0, cp2.stderr
+
+    cp3 = run(
+        [
+            "python3",
+            "scripts/plan_word_budget.py",
+            "--selected",
+            str(selected),
+            "--config",
+            str(FIXTURES / "test_config.yaml"),
+            "--output-dir",
+            str(artifacts),
+            "--review-level",
+            "premium",
+        ],
+        ROOT,
+    )
+    assert cp3.returncode == 0, cp3.stderr
+
+    assert bib.exists()
+    assert rationale.exists()
+    assert (artifacts / "word_budget_final.csv").exists()
+
+    stats = json.loads(cp2.stdout.strip())
+    assert stats["selected"] == 3

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import config_loader
+
+
+def test_load_config_uses_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("api:\n  semantic_scholar:\n    timeout: 10\n", encoding="utf-8")
+    monkeypatch.setattr(config_loader, "_CONFIG_PATH", cfg)
+    config_loader.reload_config()
+
+    first = config_loader.load_config()
+    cfg.write_text("api:\n  semantic_scholar:\n    timeout: 99\n", encoding="utf-8")
+    second = config_loader.load_config()
+
+    assert first["api"]["semantic_scholar"]["timeout"] == 10
+    assert second["api"]["semantic_scholar"]["timeout"] == 10
+
+
+def test_load_config_force_reload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("api:\n  semantic_scholar:\n    timeout: 10\n", encoding="utf-8")
+    monkeypatch.setattr(config_loader, "_CONFIG_PATH", cfg)
+    config_loader.reload_config()
+
+    config_loader.load_config()
+    cfg.write_text("api:\n  semantic_scholar:\n    timeout: 99\n", encoding="utf-8")
+    loaded = config_loader.load_config(force_reload=True)
+
+    assert loaded["api"]["semantic_scholar"]["timeout"] == 99
+
+
+def test_env_override_applies_timeout_and_rate(monkeypatch: pytest.MonkeyPatch) -> None:
+    config_loader.reload_config()
+    monkeypatch.setenv("SLR_API_TIMEOUT", "42")
+    monkeypatch.setenv("SLR_RATE_LIMIT", "77")
+    monkeypatch.setenv("ADS_API_TOKEN", "token-x")
+
+    cfg = config_loader._apply_env_overrides({})
+
+    assert cfg["api"]["semantic_scholar"]["timeout"] == 42
+    assert cfg["api"]["openalex"]["timeout"] == 42
+    assert cfg["api"]["ads"]["timeout"] == 42
+    assert cfg["api"]["semantic_scholar"]["rate_limit"] == 77
+    assert cfg["api"]["ads"]["token"] == "token-x"
+
+
+def test_missing_config_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    missing = tmp_path / "missing.yaml"
+    monkeypatch.setattr(config_loader, "_CONFIG_PATH", missing)
+    config_loader.reload_config()
+
+    with pytest.raises(FileNotFoundError):
+        config_loader.load_config(force_reload=True)

--- a/tests/unit/test_plan_word_budget.py
+++ b/tests/unit/test_plan_word_budget.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import plan_word_budget
+
+
+def test_load_outline_default_contains_non_cited_sections() -> None:
+    sections = plan_word_budget.load_outline(None, ["topic-a"])
+    titles = [s.title for s in sections]
+    assert "引言" in titles
+    assert "讨论" in titles
+    assert "展望" in titles
+    assert "结论" in titles
+
+
+def test_allocate_within_section_returns_empty_pid_for_non_cited() -> None:
+    section = plan_word_budget.Section("s1", "引言", False, 1.0, None)
+    rows = plan_word_budget.allocate_within_section(section, [], 100, 0.6, 0.4, 0.1)
+
+    assert rows == [("", "引言", 60.0, 40.0)]
+
+
+def test_run_once_is_deterministic_given_seed() -> None:
+    sections = [
+        plan_word_budget.Section("s1", "主题", True, None, "A"),
+        plan_word_budget.Section("s2", "结论", False, 1.0, None),
+    ]
+    papers = [plan_word_budget.Paper("p1", "A", 8.0), plan_word_budget.Paper("p2", "A", 6.0)]
+    cfg = {"ratio": {"cited": 0.7, "non_cited": 0.3}, "summary_ratio": 0.55, "commentary_ratio": 0.45, "noise_strength": 0.2}
+
+    r1 = plan_word_budget.run_once(sections, papers, 1000, cfg, 17)
+    r2 = plan_word_budget.run_once(sections, papers, 1000, cfg, 17)
+
+    assert r1 == r2
+
+
+def test_infer_target_words_reads_midpoint(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "scoring:\n  default_word_range:\n    premium:\n      min: 1000\n      max: 2000\n",
+        encoding="utf-8",
+    )
+
+    target = plan_word_budget.infer_target_words(cfg, "premium")
+    assert target == 1500

--- a/tests/unit/test_select_references.py
+++ b/tests/unit/test_select_references.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import select_references
+
+
+def test_select_papers_dedup_and_target() -> None:
+    papers = [
+        {"doi": "10.1/a", "title": "A", "year": 2020, "score": 9, "abstract": "x" * 100},
+        {"doi": "10.1/a", "title": "A duplicate", "year": 2020, "score": 1, "abstract": "x" * 100},
+        {"doi": "10.1/b", "title": "B", "year": 2021, "score": 8, "abstract": "x" * 100},
+    ]
+    selected, rationale = select_references._select_papers(
+        papers,
+        min_refs=1,
+        max_refs=3,
+        target_refs=2,
+        high_score_min=0.5,
+        high_score_max=0.5,
+        min_abstract_chars=80,
+    )
+
+    assert len(selected) == 2
+    assert rationale["total_candidates"] == 2
+
+
+def test_select_papers_marks_missing_abstract_do_not_cite() -> None:
+    papers = [
+        {"doi": "10.1/a", "title": "A", "score": 9, "abstract": "x" * 100},
+        {"doi": "10.1/b", "title": "B", "score": 8, "abstract": "short"},
+    ]
+    selected, rationale = select_references._select_papers(
+        papers,
+        min_refs=1,
+        max_refs=3,
+        target_refs=2,
+        high_score_min=0.8,
+        high_score_max=0.8,
+        min_abstract_chars=80,
+    )
+
+    assert len(selected) == 2
+    assert rationale["missing_abstract_selected"] == 1
+    missing = [p for p in selected if p.get("doi") == "10.1/b"][0]
+    assert missing["do_not_cite"] is True
+    assert "missing_abstract" in missing["quality_warnings"]
+
+
+def test_bib_key_uniqueness_case_insensitive() -> None:
+    used: set[str] = set()
+    k1 = select_references._make_unique_key("Ref", used)
+    k2 = select_references._make_unique_key("ref", used)
+
+    assert k1 == "Ref"
+    assert k2 == "ref1"
+
+
+def test_escape_bib_value_special_chars() -> None:
+    escaped, counts = select_references._escape_bib_value("A&B_100%")
+
+    assert escaped == r"A\&B\_100\%"
+    assert counts["&"] == 1
+    assert counts["_"] == 1
+    assert counts["%"] == 1

--- a/tests/unit/test_validate_counts.py
+++ b/tests/unit/test_validate_counts.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import validate_counts
+
+
+def test_extract_body_removes_math_comments_and_commands() -> None:
+    tex = r"""
+\documentclass{article}
+\begin{document}
+正文中文 ABC % 注释
+$E=mc^2$
+\section{标题}更多内容
+\begin{verbatim}ignore me\end{verbatim}
+\end{document}
+"""
+    body, notes = validate_counts.extract_body(tex)
+
+    assert "注释" not in body
+    assert "E=mc" not in body
+    assert "ignore me" not in body
+    assert "标题" in body
+    assert notes
+
+
+def test_count_words_counts_cn_en_digits() -> None:
+    total, cn, en, digits = validate_counts.count_words("中文A test 2024")
+    assert cn == 2
+    assert en == 1
+    assert digits == 1
+    assert total == 3
+
+
+def test_extract_cite_keys_deduplicates() -> None:
+    tex = r"Text \cite{a,b} and \citet[see]{b,c}."
+    keys = validate_counts.extract_cite_keys(tex)
+    assert keys == {"a", "b", "c"}
+
+
+def test_load_thresholds_prefers_override() -> None:
+    config = {
+        "validation": {
+            "words": {"min": {"premium": 100}, "max": {"premium": 300}},
+            "references": {"min": {"premium": 10}, "max": {"premium": 20}},
+        }
+    }
+    min_words, min_cites, max_words, max_cites = validate_counts.load_thresholds(config, "premium", 120, 12)
+    assert (min_words, min_cites, max_words, max_cites) == (120, 12, 300, 20)


### PR DESCRIPTION
### Motivation

- 为实现 PR 中的“第一阶段测试骨架”计划，先在不改动主流程与产物契约的前提下搭建最小可持续的离线 pytest 骨架以保证脚本可回归验证。 

### Description

- 新增正式测试目录结构：`tests/unit/`、`tests/cli/`、`tests/integration/`、`tests/fixtures/`，并添加 `tests/conftest.py` 以便直接导入 `scripts/` 模块。 
- 为核心脚本补充高价值测试用例：`config_loader.py`、`select_references.py`、`plan_word_budget.py`、`validate_counts.py`，并新增离线 integration 用例覆盖 `dedupe_papers.py -> select_references.py -> plan_word_budget.py`。 
- 增加 CLI 契约测试（如 `validate_counts.py --help` 与缺失输入返回码断言），并添加测试 fixtures（最小 tex、papers jsonl、test config）。 
- 更新项目文档与依赖：在 `README.md` 补充离线测试运行说明，`CHANGELOG.md` 记录新增项，`requirements.txt` 中加入 `pytest`。 

### Testing

- 执行了 `python3 -m py_compile scripts/*.py`，编译通过（存在仓库内既有 `SyntaxWarning` 提示，但非本次改动引入）。 
- 运行 `pytest -q tests/unit tests/cli tests/integration` 并通过全部测试（`19 passed`）。
- 在本地验证过程中未依赖外部 API 或 LaTeX 工具链，保持离线、可复现的最小回归集。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aea55444188328856580b99ed327da)